### PR TITLE
Enable CPUQuiet on togari defconfig

### DIFF
--- a/arch/arm/configs/rhine_lp_togari_moj_defconfig
+++ b/arch/arm/configs/rhine_lp_togari_moj_defconfig
@@ -757,7 +757,7 @@ CONFIG_CPU_IDLE_GOV_MENU=y
 #
 # CPUQuiet hotplugging framework
 #
-# CONFIG_CPU_QUIET is not set
+CONFIG_CPU_QUIET=y
 CONFIG_CPU_FREQ_MSM=y
 
 #


### PR DESCRIPTION
Enables CPUQuiet Framework on togari defconfig

So Armestia is the first kernel for 5.1.1 which supports CPUQUIET
