### PR TITLE
Enable CPUQuiet om honami defconfig

### DIFF
--- a/arch/arm/configs/rhine_lp_honami_moj_defconfig
+++ b/arch/arm/configs/rhine_lp_honami_moj_defconfig
@@ -761,7 +761,7 @@ CONFIG_CPU_IDLE_GOV_MENU=y
 #
 # CPUQuiet hotplugging framework
 #
-# CONFIG_CPU_QUIET is not set
+CONFIG_CPU_QUIET=y
 CONFIG_CPU_FREQ_MSM=y
 
 #


### PR DESCRIPTION
Enables on honami defconfig the CPUQuiet Framework

So that's the first kernel for 5.1.1 and for 3.4 kernel which supports CPUQUIET 
